### PR TITLE
Increase Lambda timeout

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,3 +8,4 @@
   },
   "postCreateCommand": "pip install -r requirements.txt && pip install localstack"
 }
+

--- a/main.tf
+++ b/main.tf
@@ -115,6 +115,7 @@ resource "aws_lambda_function" "copy_function" {
   handler          = "lambda_function.lambda_handler"
   runtime          = "python3.11"
   source_code_hash = data.archive_file.lambda_zip.output_base64sha256
+  timeout          = 30
 
   environment {
     variables = {

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ boto3
 localstack-client
 localstack
 awscli
+


### PR DESCRIPTION
## Summary
- increase AWS Lambda timeout to 30 seconds
- fix newline endings in requirements/devcontainer files

## Testing
- `terraform init -backend=false`
- `terraform validate`
- `terraform plan -out=tfplan`
- `localstack start -d` *(fails: Docker could not be found)*


------
https://chatgpt.com/codex/tasks/task_e_6844722dd994832cbba0b5932f6c89e2